### PR TITLE
Adding address support (Fixes issues #3)

### DIFF
--- a/client/css/brewmap.css
+++ b/client/css/brewmap.css
@@ -45,3 +45,8 @@ table, th, td {
     border: 1px solid black;
 }
 
+.details, .details h3{margin-bottom:0;}
+.address{margin-bottom:10px;}
+.details p{margin:0 !important; padding:0 !important;}
+.edit{color:gray; font-size:80%; margin-top:10px !important;}
+.edit a{color:gray !important;}


### PR DESCRIPTION
Adds support for reverse address look-ups using Nominatim queries in the JS client. This makes use of JQueries JSONP, i.e., cross-domain ajax queries.

Currently the server being used is open.mapquestapi.com/nominatim/v1/, which doesn't have any explicit usage limits.

I've had to rearrange the pop-up content and add some CSS to try to get things to not look too awful.
