### PR TITLE
Using available addr:* tags in preference to Nominatim data

### DIFF
--- a/client/css/brewmap.css
+++ b/client/css/brewmap.css
@@ -45,8 +45,21 @@ table, th, td {
     border: 1px solid black;
 }
 
-.details, .details h3{margin-bottom:0;}
-.address{margin-bottom:10px;}
-.details p{margin:0 !important; padding:0 !important;}
-.edit{color:gray; font-size:80%; margin-top:10px !important;}
-.edit a{color:gray !important;}
+/* Pop-up styling */
+.details, .details h3 {
+    margin-bottom:0;
+}
+.address {
+    margin-bottom:10px;
+}
+.details p {
+    margin:0 !important;
+    padding:0 !important;
+}
+.edit {
+    font-size:80%;
+    margin-top:10px !important;
+}
+.edit, .edit a, .marked {
+    color:gray !important;
+}

--- a/client/js/brewmap.js
+++ b/client/js/brewmap.js
@@ -130,15 +130,14 @@ function loadDataSuccess(dataObj,layerName) {
 
 	    var marker = new L.Marker(posN, {icon: layer['icon']});
 
-	    marker.brewmap = {};
-	    marker.brewmap.osm_id = entity_obj['osm_id'];
-	    marker.brewmap.type = entity_obj['type'];
+
+	    marker.brewmap = entity_obj;
 
 	    marker.bindPopup(popup.content(entity_obj));
 	    marker.on('click', function(e) {
 		address.target = e.target;
 		var data = e.target.brewmap;
-		address.search(data.osm_id, data.type);
+		address.search(data);
 	    });
 	    map.addLayer(marker);
 	
@@ -281,9 +280,13 @@ function updatePermaLink() {
 
 var address = {
 	url: 'http://open.mapquestapi.com/nominatim/v1/reverse?',
-	search: function (id, type) {
-		this.id = id;
-		this.type = type;
+	data: {},
+	search: function (entity_data) {
+		console.log(entity_data);
+	
+		this.id = entity_data.id;
+		this.type = entity_data.type;
+		this.osm = entity_data;
 		this.make_query();
 		this.get();
 	},
@@ -297,7 +300,7 @@ var address = {
 				type_char = 'W';
 				break;
 			default:
-				console.log(type_char)
+				console.log(type_char);
 				throw "Failed to match entity type";
 				return;
 		}
@@ -305,25 +308,95 @@ var address = {
 				type_char,'&format=json&json_callback=?'].join('');
 		console.log(this.query);
 	},
-	add: function(data) {
-		var name_arr = data.display_name.split(',');
-		var first_bits_arr = name_arr.slice(1,4);
-	
-		console.log(data);
-	
-		// Check for postcode
-		if(data.address.postcode !== undefined) {
-			first_bits_arr.push(data.address.postcode);
+	// Check for data that needs to be merged
+	// Trying to use names consistent with addr:*
+	process: function() {
+		var osm = this.osm;
+		var nominatim = this.nominatim;
+		var marked = {};
+		var merged = {'housenumber': osm['addr:housenumber'],
+				'street': osm['addr:street'],
+				'postcode': osm['addr:postcode'],
+				'city': osm['addr:city']};
+
+		if(nominatim.house_number !== undefined &&
+		merged.housenumber === undefined) {
+			merged.housenumber = nominatim.house_number;
+			marked.housenumber = true;
 		}
-		if(data.address.house_number !== undefined) {
-			if(data.address.house_number === first_bits_arr[0].trim()) {
-				var joined_num_and_st = first_bits_arr.splice(0,2).join(' ');
-				first_bits_arr.unshift(joined_num_and_st);
+		if(nominatim.road !== undefined &&
+		merged.street === undefined) {
+			merged.street = nominatim.road;
+			marked.street = true;
+		}
+		if(nominatim.town !== undefined &&
+		merged.city === undefined) {
+			merged.city = nominatim.town;
+			marked.city = true;
+		}
+		else if(nominatim.city !== undefined &&
+		merged.city === undefined) {
+			merged.city = nominatim.city;
+			marked.city = true;
+		}
+
+		if(nominatim.postcode !== undefined &&
+		merged.postcode === undefined) {
+			merged.postcode = nominatim.postcode;
+			marked.postcode = true;
+		}
+
+		if(nominatim.suburb !== undefined) {
+			merged.suburb = nominatim.suburb;
+			marked.suburb = true;
+		}
+
+		if(nominatim.county !== undefined) {
+			merged.county = nominatim.county;
+			marked.county = true;
+		}
+		
+		this.merged = merged;
+		this.marked = marked;
+	},
+	add: function() {
+		this.process();
+
+		var merged = this.merged;
+		var marked = this.marked;
+		console.log(merged);
+
+		var to_add = [[merged.suburb,marked.suburb], [merged.city,marked.city], [merged.county,marked.county],[merged.postcode,marked.postcode]];
+		var to_add_len = to_add.length;
+		var bits = [];
+
+		// Merge house number and street together where appropriate
+		if(merged.housenumber !== undefined &&
+		merged.street !== undefined) {
+			bits.push([merged.housenumber,' ',merged.street].join(''));
+		}
+		else if(merged.street !== undefined) {
+			var street_value = merged.street;
+			if(marked.street === true) {
+				street_value = ['<span class="marked">',street_value,'</span>'].join('');
+			}
+			bits.push(street_value);
+		}
+
+		// Loop through address data adding to bits
+		for(var i=0; i<to_add_len; i++) {
+			var to_add_i = to_add[i];
+			if(to_add_i[0] !== undefined) {
+				var value = to_add_i[0];
+				if(to_add_i[1] === true) {
+					value = ['<span class="marked">',value,'</span>'].join('');
+				}
+				bits.push(value);
 			}
 		}
 
 		$(this.target._popup._contentNode).find('div.address')
-			.html(first_bits_arr.join(',<br />'));
+			.html(bits.join(',<br />'));
 	},
 	get: function() {
 		var data = jQuery.getJSON(this.query, function(data) {
@@ -332,7 +405,9 @@ var address = {
 				console.log(data.error);
 				return false;
 			}
-			address.add(data);		
+			address.nominatim = data.address;
+			console.log(address.nominatim);
+			address.add();
 		});
 	}	
 }

--- a/client/js/brewmap.js
+++ b/client/js/brewmap.js
@@ -258,11 +258,10 @@ function editButtonCallback() {
     var swPoint = bounds.getSouthWest();
     var nePoint = bounds.getNorthEast();
     var zoom = map.getZoom();
-    var url = "http://www.openstreetmap.org/edit?bbox="
-	+ swPoint.lng + "%2C" + swPoint.lat + "%2C" 
-	+ nePoint.lng + "%2C" + nePoint.lat
-    window.open(url);
-    
+    var url = ["http://www.openstreetmap.org/edit?bbox=",
+	swPoint.lng, "%2C", swPoint.lat, "%2C" 
+	, nePoint.lng, "%2C", nePoint.lat].join('');
+    window.open(url); 
 }
 
 function updatePermaLink() {
@@ -273,9 +272,9 @@ function updatePermaLink() {
     var curLon = centrePt.lng;
     var curZoom = map.getZoom();
     var pageURL = document.location.href.split('?')[0];
-    var hrefURL = pageURL + '?lon='+curLon+'&lat='+curLat+'&z='+curZoom;
-    jQuery('#permaLink').attr('href',hrefURL);
-    
+    var hrefURL = [pageURL, '?lon=', curLon, '&lat=', curLat, '&z=',
+        curZoom].join('');
+    jQuery('#permaLink').attr('href',hrefURL); 
 }
 
 var address = {

--- a/client/js/brewmap.js
+++ b/client/js/brewmap.js
@@ -282,8 +282,6 @@ var address = {
 	url: 'http://open.mapquestapi.com/nominatim/v1/reverse?',
 	data: {},
 	search: function (entity_data) {
-		console.log(entity_data);
-	
 		this.id = entity_data.id;
 		this.type = entity_data.type;
 		this.osm = entity_data;
@@ -300,13 +298,12 @@ var address = {
 				type_char = 'W';
 				break;
 			default:
-				console.log(type_char);
 				throw "Failed to match entity type";
 				return;
 		}
 		this.query = [this.url,'osm_id=',this.id,'&osm_type=',
 				type_char,'&format=json&json_callback=?'].join('');
-		console.log(this.query);
+		console.info(this.query);
 	},
 	// Check for data that needs to be merged
 	// Trying to use names consistent with addr:*
@@ -318,6 +315,14 @@ var address = {
 				'street': osm['addr:street'],
 				'postcode': osm['addr:postcode'],
 				'city': osm['addr:city']};
+
+		if(nominatim === undefined) {
+			console.warn('No Nominatim data, so not merging',address.process);
+			
+			this.merged = merged;
+			this.marked = marked;
+			return false;	
+		}
 
 		if(nominatim.house_number !== undefined &&
 		merged.housenumber === undefined) {
@@ -364,7 +369,6 @@ var address = {
 
 		var merged = this.merged;
 		var marked = this.marked;
-		console.log(merged);
 
 		var to_add = [[merged.suburb,marked.suburb], [merged.city,marked.city], [merged.county,marked.county],[merged.postcode,marked.postcode]];
 		var to_add_len = to_add.length;
@@ -381,6 +385,13 @@ var address = {
 				street_value = ['<span class="marked">',street_value,'</span>'].join('');
 			}
 			bits.push(street_value);
+		}
+		else {
+			var house_value = merged.housenumber;
+			if(marked.housenumber === true) {
+				house_value = ['<span class="marked">',house_value,'</span>'].join('');
+			}
+			bits.push(house_value);
 		}
 
 		// Loop through address data adding to bits
@@ -402,11 +413,11 @@ var address = {
 		var data = jQuery.getJSON(this.query, function(data) {
 			// Nominatim will set the error property
 			if(data.error !== undefined) {
-				console.log(data.error);
-				return false;
+				console.warn(data.error,address.get);
 			}
-			address.nominatim = data.address;
-			console.log(address.nominatim);
+			else {
+				address.nominatim = data.address;
+			}
 			address.add();
 		});
 	}	

--- a/client/js/brewmap.js
+++ b/client/js/brewmap.js
@@ -284,6 +284,11 @@ var address = {
 		this.id = entity_data.id;
 		this.type = entity_data.type;
 		this.osm = entity_data;
+
+		this.marked = {};
+		this.merged = {};
+		this.nominatim = {};
+
 		this.make_query();
 		this.get();
 	},
@@ -309,7 +314,7 @@ var address = {
 	process: function() {
 		var osm = this.osm;
 		var nominatim = this.nominatim;
-		var marked = {};
+		var marked = this.marked;
 		var merged = {'housenumber': osm['addr:housenumber'],
 				'street': osm['addr:street'],
 				'postcode': osm['addr:postcode'],
@@ -413,6 +418,7 @@ var address = {
 			// Nominatim will set the error property
 			if(data.error !== undefined) {
 				console.warn(data.error,address.get);
+				address.nominatim = undefined;
 			}
 			else {
 				address.nominatim = data.address;


### PR DESCRIPTION
This is a start of the work to address the concerns raised by Tom Chance about the visibility of missing address data.

Currently, the code will merge the 2 sets with preference to the addr:\* tags, and for each address line that is derived from Nominatim wrap it in a span with the class "marked". Included is a simple css rule to change these lines to be grey.

A requirement of this to work well is obviously having all the available addr:\* tags included in JSON.

I can add a tooltip to inform users what this means, but I think in terms of visibility it would be better to have a "entities with no addr:\* tags" list. That way people who particularly care about addressing can get straight to it.
